### PR TITLE
Updated URL link to FERIT webpage

### DIFF
--- a/app/src/main/java/os/dtakac/feritraspored/common/constants/ScheduleUrls.kt
+++ b/app/src/main/java/os/dtakac/feritraspored/common/constants/ScheduleUrls.kt
@@ -9,6 +9,6 @@ fun getScheduleUrl(scheduleLanguage: ScheduleLanguage): String {
 }
 
 private val SCHEDULE_URLS = mapOf(
-        ScheduleLanguage.HR to "https://www.ferit.unios.hr/2021/studenti/raspored-nastave-i-ispita/%s/%s",
-        ScheduleLanguage.EN to "https://www.ferit.unios.hr/2021/students/schedule-of-classes-and-exams/%s/%s"
+        ScheduleLanguage.HR to "https://www.ferit.unios.hr/studenti/raspored-nastave-i-ispita/%s/%s",
+        ScheduleLanguage.EN to "https://www.ferit.unios.hr/students/schedule-of-classes-and-exams/%s/%s"
 )


### PR DESCRIPTION
Pozdrav,
Vidim već neko vrijeme ne radi raspored a postao sam kroz ove 4. god faksa ovisan o njemu pa sam ga brzinski fixao, problem je bio url koji su izmijenili, sve ostalo je identično. Ubuduće ako naletim na bugove ću ti rokat pull requestove kako bi to išlo brže.
P.S. Stavi mi credit na update notification pa se možda studenti nalože na održavanje rasporeda jer nema smisla da jedna osoba to radi ako svi koriste.
Lijep pozdrav,

Leon Gal